### PR TITLE
Fix Registration Delta Composition Bug

### DIFF
--- a/loam/include/loam/registration-inl.h
+++ b/loam/include/loam/registration-inl.h
@@ -60,7 +60,7 @@ Pose3d registerFeatures(const LoamFeatures<PointType, Alloc>& source, const Loam
     }
 
     // Update the solution
-    target_T_source_est = target_T_source_est.compose(estimate_update);
+    target_T_source_est = estimate_update.compose(target_T_source_est);
 
     // Check for convergence - defined as when the computed update is sufficiently small
     const double angle_change = estimate_update.rotation.angularDistance(Eigen::Quaterniond::Identity());

--- a/loam/src/registration.cpp
+++ b/loam/src/registration.cpp
@@ -49,6 +49,10 @@ std::vector<std::pair<size_t, size_t>> associateEdges(const RegistrationParams& 
     if (condition_number < params.min_line_condition_number) continue;  // GUARD: Edge points not co-linear
 
     // Construct the cost function and add it to the problem
+    // Note the point has already been transformed by the current estimate
+    // Therefore WRT the edge cost function class
+    //     - The source frame = current estimate of the target frame
+    //     - The target frame = the "true" target frame
     problem.AddResidualBlock(EdgeCostFunction::Create(point_tgt, line), new ceres::HuberLoss(1.0),
                              estimate_update.rotation.coeffs().data(), estimate_update.translation.data());
     // Accumulate the association
@@ -86,6 +90,10 @@ std::vector<std::pair<size_t, size_t>> associatePlanes(const RegistrationParams&
     if (avg_dist > params.max_avg_point_plane_dist) continue;  // GUARD: Plane points not co-planar
 
     // Construct the cost function and add it to the problem
+    // Note the point has already been transformed by the current estimate
+    // Therefore WRT the plane cost function class 
+    //     - The source frame = current estimate of the target frame
+    //     - The target frame = the "true" target frame
     problem.AddResidualBlock(PlaneCostFunction::Create(point_tgt, plane), new ceres::HuberLoss(1.0),
                              estimate_update.rotation.coeffs().data(), estimate_update.translation.data());
     // Accumulate the association


### PR DESCRIPTION
There was previously a bug in the registration code logic originally pointed out in #1

During Registration... 

Source points (`p_s`) are transformed by the current solution (`p_te = t_T_s * p_s`) so they are in the "Target Estimate" frame. We then re-associate points and compute a relative pose to transform these points into the "Target True" frame (`p_tt = T_delta * (t_T_s * p_s`)).

From this we can clearly see that `T_delta` is composed on the left with the current `t_T_s` estimate. However, in the code, we were composing this delta on the right.

This PR fixes this bug, adds a unit test to ensure future correctness, and better documents the meaning of the estimate update.