### PR TITLE
Fix `nanoflann` Target Name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ FetchContent_MakeAvailable(nanoflann)
 file(GLOB loam_srcs "${CMAKE_CURRENT_SOURCE_DIR}/loam/src/*.cpp")
 file(GLOB loam_hdrs "${CMAKE_CURRENT_SOURCE_DIR}/loam/include/loam/*.h")
 add_library(loam SHARED ${loam_srcs} ${loam_hdrs})
-target_link_libraries(loam PUBLIC Eigen3::Eigen Ceres::ceres nanoflann)
+target_link_libraries(loam PUBLIC Eigen3::Eigen Ceres::ceres nanoflann::nanoflann)
 target_include_directories(loam PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/loam/include")
 
 # If testing is configured, setup the tests


### PR DESCRIPTION
Older versions of nanoflann (e.g. 1.5.5 used by default here) seem to accept `nanoflann` or `nanoflann::nanoflann` but newer versions that folks may use only accept `nanoflann::nanoflann` so we update the naming here.